### PR TITLE
Python ランタイムを 3.11 に更新

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 jobs:
   build-and-lint:
     docker: 
-      - image: circleci/python:3.8
+      - image: circleci/python:3.11
     steps:
       - checkout
       - run: make venv
@@ -11,7 +11,7 @@ jobs:
       - run: make lint
   deploy:
     docker:
-      - image: circleci/python:3.8
+      - image: circleci/python:3.11
     steps:
       - checkout
       - run: sudo apt-get -y update

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 AWS=aws
-PYTHON_RUNTIME=python3.8
+PYTHON_RUNTIME=python3.11
 ACTIVATE=. venv/bin/activate;
 PYTHON=$(ACTIVATE) python
 PIP=$(ACTIVATE) pip
@@ -26,7 +26,7 @@ lambda/update: package
 
 package: dist
 	cp billing.py $</billing.py
-	cp -r venv/lib/python3.8/site-packages/* $</
+	cp -r venv/lib/python3.11/site-packages/* $</
 	cd $< && zip -r ${package_file_name} ./*
 	mv -f $</$(package_file_name) ./$(package_file_name)
 


### PR DESCRIPTION
## 概要
- AWS Lambda の最新ランタイムに合わせて `PYTHON_RUNTIME` を `python3.11` に更新しました
- CircleCI の実行イメージも `circleci/python:3.11` に更新しました

## テスト結果
- `make lint` を実行し、エラーが無いことを確認しました


------
https://chatgpt.com/codex/tasks/task_e_684865c7f5b083329ea847a4aedfe7db