### PR TITLE
GitHub Actionsで定期実行を追加

### DIFF
--- a/.github/workflows/run_billing.yml
+++ b/.github/workflows/run_billing.yml
@@ -1,0 +1,25 @@
+name: Run Billing Script
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 9 * * *'
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.8'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+      - name: Run billing script
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+        run: |
+          python billing.py
+


### PR DESCRIPTION
## 変更内容
- 毎日18時(JST)に`billing.py`を実行するGitHub Actionsを追加しました
- `workflow_dispatch` により手動実行も可能です

必要な環境変数:
- `SLACK_WEBHOOK_URL`: Slack通知に使用するWebhook URL

```
name: Run Billing Script
on:
  workflow_dispatch:
  schedule:
    - cron: '0 9 * * *'
```

LABEL: AI_Codex

------
https://chatgpt.com/codex/tasks/task_e_68486c7f9afc833281a939dcfd221be7