### PR TITLE
GitHub Actions で lint 実行を追加

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   push:
-    branches: [ main ]
+    branches: [ master ]
   pull_request:
 
 jobs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,18 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - run: make venv
+      - run: make install
+      - run: make lint


### PR DESCRIPTION
## 概要
CircleCI 相当の処理を GitHub Actions で行うワークフローを追加しました。

## 変更点
- `.github/workflows/ci.yml` を新規作成し、`make venv`→`make install`→`make lint` を実行

## テスト
- `make clean && make venv && make install && make lint` を実行し lint が成功することを確認

ラベル: `AI_Codex`


------
https://chatgpt.com/codex/tasks/task_e_6848c8bbb9348332818e8032244db139